### PR TITLE
fix: (opam-switch-mode) × 3 bug

### DIFF
--- a/opam-switch-mode.el
+++ b/opam-switch-mode.el
@@ -292,7 +292,7 @@ not any other shells outside emacs."
 
 (defun opsw--menu-items ()
   "Create list of opam switches as menu items for `easy-menu'."
-  (nconc
+  (append
    ;; first the current switch as info with a separator
    '(["current switch: " nil
       :active t


### PR DESCRIPTION
The precondition of `nconc` did not hold.

§ https://www.gnu.org/software/emacs/manual/html_node/elisp/Rearrangement.html

```
Function: nconc &rest lists ¶

[…] all arguments (all but the last) should be mutable lists.

A common pitfall is to use a constant list as a non-last argument to 'nconc'.
If you do this, the resulting behavior is undefined.
```

Close #2