### PR TITLE
Minor tweaks and cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/opam-switch-mode-autoloads.el
+/opam-switch-mode-pkg.el
+*.elc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # opam-switch-mode
 
+[![NonGNU ELPA](https://elpa.nongnu.org/nongnu/opam-switch-mode-badge.svg)](https://elpa.nongnu.org/nongnu/opam-switch-mode.html)
 [![MELPA](https://melpa.org/packages/opam-switch-mode-badge.svg)](https://melpa.org/#/opam-switch-mode)
 
 Provide a command `opam-switch-set-switch` to change the opam switch
@@ -13,9 +14,13 @@ entry "reset" to reset the environment to the state when Emacs was started.
 
 ## Installing `opam-switch-mode`
 
-The recommended way to install this mode relies on the
-[MELPA](https://melpa.org/) repository of Emacs packages, along with the
-[`use-package`](https://github.com/jwiegley/use-package) macro.
+We recommend to install this mode from either the 
+[NonGNU ELPA](https://elpa.nongnu.org/) or the
+[MELPA](https://melpa.org/) repository of Emacs packages.
+
+If you use the
+[`use-package`](https://github.com/jwiegley/use-package) macro, the
+recommended configuration is:
 Assuming you have already set up those in your `.emacs`, just write:
 
 ```elisp
@@ -24,6 +29,10 @@ Assuming you have already set up those in your `.emacs`, just write:
   :hook
   (coq-mode . opam-switch-mode))
 ```
+
+If you don't use `use-package`, do the following instead:
+
+    (add-hook 'coq-mode-hook #'opam-switch-mode)
 
 so that the minor mode is automatically enabled when `coq-mode` is on,
 see also [`opam-switch-mode` aware modes](#opam-switch-mode-aware-modes).

--- a/opam-switch-mode.el
+++ b/opam-switch-mode.el
@@ -186,7 +186,7 @@ This function should not be called directly; see `opam-switch--root'."
       (nreverse opam-switches))))
 
 (defvar opam-switch--switch-history nil
-  "Minibuffer history list for `opam-switch--set-switch'.")
+  "Minibuffer history list for `opam-switch-set-switch'.")
 
 (defvar opam-switch--saved-env nil
   "Saved environment variables, overwritten by an opam switch.
@@ -249,7 +249,8 @@ switch overwrote them."
          (file-name-nondirectory current-switch)
       "<none>")))
 
-(defun opam-switch--set-switch (switch-name)
+;;;###autoload
+(defun opam-switch-set-switch (switch-name)
   "Choose and set an opam switch.
 Set opam switch SWITCH-NAME, which must be a valid opam switch
 name.  When called interactively, the switch name must be entered
@@ -272,7 +273,7 @@ runs.  This a can be used to inform other modes that may run
 background processes that depend on the currently active opam
 switch.
 
-For obvious reasons, `opam-switch--set-switch' will only affect Emacs and
+For obvious reasons, `opam-switch-set-switch' will only affect Emacs and
 not any other shells outside Emacs."
   (interactive
    (let* ((switches (opam-switch--get-switches))
@@ -297,11 +298,8 @@ not any other shells outside Emacs."
       (opam-switch--set-env opam-env)))
   (run-hooks 'opam-switch-change-opam-switch-hook))
 
-;; FIXME: This autoload didn't work.  If we want to autoload the command,
-;; then we need to place the autoload on the command itself (and arguably
-;; rename it without the "--").
-;; ;;;###autoload
-(defalias 'opam-switch-set-switch #'opam-switch--set-switch)
+(define-obsolete-function-alias 'opam-switch--set-switch
+  #'opam-switch-set-switch "opam-switch-mode 1.1")
 
 ;;; minor mode, keymap and menu
 
@@ -321,13 +319,13 @@ not any other shells outside Emacs."
    (mapcar
     (lambda (switch)
       `[,switch
-        (opam-switch--set-switch ,switch)
+        (opam-switch-set-switch ,switch)
         :active t
         :help ,(concat "select opam switch \"" switch "\"")])
     (opam-switch--get-switches))
    ;; now reset as last element
    '(
-     ["reset" (opam-switch--set-switch "")
+     ["reset" (opam-switch-set-switch "")
       :active opam-switch--saved-env
       :help "reset to state when emacs was started"])))
 

--- a/opam-switch-mode.el
+++ b/opam-switch-mode.el
@@ -311,7 +311,7 @@ not any other shells outside Emacs."
   (append
    ;; first the current switch as info with a separator
    '(["current switch: " nil
-      :active t
+      :active nil
       :suffix (opam-switch--get-current-switch)
       :help "Shows the currently selected opam switch"]
      "-------")
@@ -321,13 +321,13 @@ not any other shells outside Emacs."
       `[,switch
         (opam-switch-set-switch ,switch)
         :active t
-        :help ,(concat "select opam switch \"" switch "\"")])
+        :help ,(concat "Select opam switch \"" switch "\"")])
     (opam-switch--get-switches))
    ;; now reset as last element
    '(
      ["reset" (opam-switch-set-switch "")
       :active opam-switch--saved-env
-      :help "reset to state when emacs was started"])))
+      :help "Reset to state when Emacs was started"])))
 
 (defun opam-switch--setup-opam-switch-mode ()
   "Re-define menu for `opam-switch-mode'.
@@ -341,7 +341,7 @@ is automatically created by `define-minor-mode'."
     opam-switch-mode-map
     "opam mode menu"
     ;; FIXME: Use `:filter'?
-    (cons "opam-switch"
+    (cons "Opam-switch"
           (opam-switch--menu-items))))
 
 ;;;###autoload


### PR DESCRIPTION
* .gitignore: New file.

* README.md: Add link to NonGNU and insist less on the use of `use-package`.

* opam-switch-mode.el: Remove redundant `:group` arguments. (opam-switch-change-opam-switch-hook): Fix `:type`. (opam-switch--get-root): Avoid unneeded `setq`.
(opam-switch--root): Include the error info in the error message. (opam-switch--get-switches): Change regexp under the assumption that switch names don't include newlines nor TABs, and throw away the `.*$` tail which just wastes time.  Preserve the order of the switches. (opam-switch-set-switch): Comment out broken autoload cookie. (opam-switch-mode-map): Rename from `opam-switch--mode-keymap` to follow the convention.
(opam-switch--setup-opam-switch-mode): Adjust accordingly. (opam-switch--menu-items): Let backquote worry about `vconcat`. (opam-switch-mode): Remove redundant keywords.
Try and reset the environment when turning the mode off. (opam-switch--get-root, opam-switch-mode): Fix incorrect markup.